### PR TITLE
Fix deprecated GitHub upload-artifact action to v4

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,7 +28,7 @@ jobs:
         run: dotnet test --no-build --collect:"XPlat Code Coverage"
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: '**/coverage.cobertura.xml'


### PR DESCRIPTION
### Summary
This pull request updates the GitHub Actions workflow to replace the deprecated `actions/upload-artifact@v3` with the new `actions/upload-artifact@v4`.

### Reason for Change
GitHub has deprecated version 3 of the upload-artifact action, causing the pipeline to fail. Updating to v4 ensures the CI pipeline continues to run successfully and allows coverage reports to be uploaded correctly.

### Changes Made
- Updated `.github/workflows/dotnet.yml` to use `upload-artifact@v4`
- Ensures compatibility with current GitHub Actions requirements
- Allows successful upload of coverage reports

### Linked Issue
Fixes: #28
