### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,8 @@
 name: .NET Build & Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/DaleNesbitt/DemonSlayerDN/security/code-scanning/1](https://github.com/DaleNesbitt/DemonSlayerDN/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow with the minimal necessary permissions. Since all jobs in the workflow simply build, test, and upload artifacts and do not require write access to repository contents, `contents: read` is sufficient. This block should be added at the root level (before the `jobs:` key) so it applies to all jobs, unless certain jobs require more permissions (which is not the case in the provided code). No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
