### PR TITLE
Update target framework to net8.0 in test project

### DIFF
--- a/tests/DemonSlayer.Tests/DemonSlayer.Tests.csproj
+++ b/tests/DemonSlayer.Tests/DemonSlayer.Tests.csproj
@@ -1,23 +1,27 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- Match the main project framework -->
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <!-- Test packages -->
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>
 
+  <!-- Required for xUnit usage -->
   <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <!-- Reference to main project -->
   <ItemGroup>
     <ProjectReference Include="..\..\src\DemonSlayer\DemonSlayer.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Update target framework from net9.0 to net8.0. It was resulting in NO tests being run